### PR TITLE
Document page

### DIFF
--- a/docs/source/bookmarks.rst
+++ b/docs/source/bookmarks.rst
@@ -78,5 +78,4 @@ To change a bookmark's icon:
 
 Labels
 ------
-To learn more about adding labels to your bookmarks, see:
-`Labels <https://andbible.readthedocs.io/en/stable/labels.html>`_.
+To learn more about adding labels to your bookmarks, see :doc:`labels`

--- a/docs/source/bookmarks.rst
+++ b/docs/source/bookmarks.rst
@@ -4,17 +4,16 @@ Bookmarks
 Overview
 --------
 
-A bookmark is a `label <https://andbible.readthedocs.io/en/stable/labels.html>`_
-attached to a selection of text, a verse, or a range of verses.
+A bookmark is a :doc:`label <labels>` attached to a selection of text, a verse,
+or a range of verses.
 
 When a bookmark is added to an entire verse (or range of verses), the bookmark will
 be visible in all other translations. Bookmarks applied to only a selection of text
 will, however, only be visible as an icon in other translations.
 
-Multiple `labels <https://andbible.readthedocs.io/en/stable/labels.html>`_ can
-be added to a single bookmark and multiple bookmarks can be added to a single
-verse. The verse action dialog shows all bookmarks for that verse, not only the
-selected bookmark.
+Multiple :doc:`labels <labels>` can be added to a single bookmark and multiple bookmarks
+can be added to a single verse. The verse action dialog shows all bookmarks for
+that verse, not only the selected bookmark.
 
 .. raw:: html
 
@@ -28,7 +27,7 @@ To create a bookmark:
 
 1. Click on the verse you want to bookmark.
 2. In the verse action dialog, Click the `Bookmark` button.
-3. Optionally, add `labels <https://andbible.readthedocs.io/en/stable/labels.html>`_
+3. Optionally, add :doc:`labels <labels>`
    to your bookmark.
 
 To add a bookmark to part of a verse:
@@ -38,7 +37,7 @@ To add a bookmark to part of a verse:
 3. Choose `Selection` or `Bookmark > Selection` (the options displayed are
    controlled by the 'One-step bookmarking' application preference).
    Choosing `Verses` bookmarks the whole verse.
-4. Optionally, add `labels <https://andbible.readthedocs.io/en/stable/labels.html>`_
+4. Optionally, add :doc:`labels <labels>`
    to the bookmark.
 
 To add a bookmark to multiple verses:
@@ -48,8 +47,7 @@ To add a bookmark to multiple verses:
    The following verse is automatically selected.
 3. Click on a later verse to extend the verse range.  To shorten the range,
    Click any verse in the existing range and the range will end at that verse.
-4. Click the `Bookmark` button and optionally select a
-   `label <https://andbible.readthedocs.io/en/stable/labels.html>`_.
+4. Click the `Bookmark` button and optionally select a :doc:`label <labels>`.
 
 .. raw:: html
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,46 +3,45 @@
 # -- Project information
 rst_prolog = """
 .. |app| replace:: *AndBible*
-.. |hamburger| replace:: ☰ 
+.. |hamburger| replace:: ☰
 """
 
-project = 'AndBible: Bible Study'
-copyright = '2022, And Bible Open Source Project'
-author = 'And Bible Open Source Project'
+project = "AndBible: Bible Study"
+copyright = "2025, And Bible Open Source Project"
+author = "And Bible Open Source Project"
 
-release = '0.1'
-version = '0.1.0'
+release = "0.1"
+version = "0.1.0"
 
 # -- General configuration
 
 extensions = [
-    'sphinx.ext.duration',
-    'sphinx.ext.doctest',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.autosectionlabel',
+    "sphinx.ext.duration",
+    "sphinx.ext.doctest",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.autosectionlabel",
 ]
 
 # Make sure the target is unique
 autosectionlabel_prefix_document = True
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+    "python": ("https://docs.python.org/3/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
 }
-intersphinx_disabled_domains = ['std']
+intersphinx_disabled_domains = ["std"]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # -- Options for HTML output
 
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # -- Options for EPUB output
-epub_show_urls = 'footnote'
+epub_show_urls = "footnote"
+
 
 def setup(app):
-    app.add_css_file('custom.css')
-
-
+    app.add_css_file("custom.css")

--- a/docs/source/documents.rst
+++ b/docs/source/documents.rst
@@ -1,65 +1,111 @@
-Document Library
-================
+Documents
+=========
 
 Overview
 --------
 
-Document library contains the list of all Bibles, dictionaries, commentaries, books, and other modules that have been download.
-To access the library tap and hold on the book name on the top left side of the menu bar.
+|app| supports various document modules: `Bibles`_, `Commentaries`_, `Dictionaries`_
+`Books`_, and `Maps`_. You can `Download Documents`_, :doc:`backup_restore`
+documents, and `Load Documents`_ from your device's filesystem.
+
+Document Library
+----------------
+
+The `Document Library` contains the list of all Bibles, commentaries, dictionaries,
+books, and other modules that have been download.
+The `Document Library` can be accessed in a few different ways:
+
+  - Click and hold on the document name on the top of the menu bar.
+  - Click the top left |hamburger| icon and click `Choose Document`.
 
 Bibles
 ------
 
-Bible modules can be downloaded from going to main menu then taping on download documents.
-You can filter the list by selecting bibles for "All Types" or by language.
+Bibles modules can be installed in different languages, translations, and formats.
+Many Bible modules contain Strong's numbers, footnotes, cross-references, and study notes.
 
 Commentaries
 ------------
 
-To do.
+Commentaries contain explanations or interpretations of other Bibles or books.
+Many commentaries will contain interactive Bible references, and can be
+:doc:`navigated <navigation>` like Bible modules.
 
 Dictionaries
 ------------
 
-To install strong's concordance dictionaries tap on the top left on the menu bar then tap on download documents. 
-For "All Types" select Dictionary. From the list tap on StrongsGreek to install then StrongHebrew.
+Dictionaries provide additional information about individual words. |app| supports
+Greek and Hebrew Strong's dictionaries, Robinson's Greek morphology, and others.
 
-To ensure that these dictionaries are used as main lookup for words in Bible modules:
-From menu select application preferences, then tap on Strongs Greek Dictionary and if not selected tap on StrongsGreek.
-Do the same for Strongs Hebrew Dictionary.
+Strong's and Robinson dictionaries can be used as the primary lookup for words
+in Strong's enabled document modules (like KJV, BSB, NASB, NET, etc):
 
-Return to download documents and download KJV Bible module if you have not installed it previously. This module contains Strong's number references.
-From the main Bible window tap and hold on the book name to the right of the menu icon on the top left of the screen.
-From the list of modules select KJV Bible. (You can also get to this screen by going to "Choose Document" in the main left side menu). This will load the current window with this Bible module. (You can also use the NASB or NET version for this purpose)
+#. From the main menu (|hamburger|) click `Application preferences`
+#. Click on `Strong's Greek Dictionary` to select the Strong's Greek dictionary you want to use.
+#. Click on `Strong's Hebrew Dictionary` to select the Strong's Hebrew dictionary you want to use.
+#. Click on `Robinson Greek morphology` to select the Robinson Greek dictionary you want to use.
+#. In the main menu toolbar, click the Greek/Hebrew icon until dotted lines appear
+   below the words.
 
-If you see dotted underlines for words, this means that a strong's no is coded for that word, if you tap on these words the window will display the dictionary definition for that word.
-To display the Strong's numbers in the bible instead of underlines inlines, tap on the Greek or Hebrew icon on the top menu bar. For the books in the Hebrew scriptures this icon shows Hebrew letters and for the books in the New Testaments the icon shows a Greek letter. If you tap on this icon again then no underline or Strong's numbers will display.
+To view the Strong's definition for a word, simply click on a word in a Strong's
+enabled Bible module.
 
-To display the dictionary definitions in a special window:
-From the main menu tap on application preferences then turn on "Links window"
+To display the Strong's numbers in the Bible instead of underlines,
+click on the Greek or Hebrew icon on the top menu bar (For books in Hebrew,
+this icon shows Hebrew letters and for books in Greek the icon shows a Greek letter).
+
+Toggling this icon can show underlines, Strong's numbers, or no links at all.
+
+It is also possible to display the dictionary definitions in a special window
+rather than a pop-up dialog:
+
+  - From the main menu (|hamburger|) click on `Application preferences` and
+    enable the `Links window` option.
 
 
 Books
 -----
 
-To do.
+Various book formats are supported by |app|. Sword modules, MyBible modules, EPUB, and
+|app| :doc:`document backups <backup_restore>` can all be imported from provided
+repositories (Sword) or directly loaded from your device's filesystem (MyBible, Backups).
 
 Maps
 ----
 
-To do.
+Map moudles can be installed through the provided repositories.
 
+Download Documents
+------------------
 
-How to Delete a Module:
-----
+Thousands of different documents can be downloaded from the provided module
+repositories.
+
+To download a document from the provided repositories:
+
+#. Click on the top left menu (|hamburger|).
+#. Click `Download documents`.
+#. Search for, and click on a document to install it.
+
+Load Documents
+--------------
+
+To load a document from your device's filesystem:
+
+#. Click on the top left menu (|hamburger|).
+#. Click `Download documents`.
+#. Click the three vertical dot menu on the right of the top menu bar.
+#. Click `Load Document From Files`.
+#. Click `Proceed` and select a document from your device's file browser.
+
+Deleting Modules
+----------------
 
 To delete any of the above module types:
 
-From the menu bar at the top;
-Tap to Enter menu, then tap on "Choose Document". Optionally you can tap and hold on the book name on the menu bar.
-This will take you to the document screen.
-Choose the type of document to filter by, e.g. Bibles, Maps, etc.
-From the list, tap and hold on the module you want to delete.
-Once highlighted, at the top right corner on the menu bar, tap on the trash can icon.
-Tap "Yes" to confirm delete.
-
+#. From the main menu (|hamburger|), click on "Choose Document".
+   (Alternatively you can click and hold on the book name in the top menu bar.)
+#. Search for the document you want to delete, or filter by the document type.
+#. Click and hold on the document you want to delete.
+#. Once highlighted, click on the trash can icon in the top menu.
+#. Click "Yes" to confirm deletion.

--- a/docs/source/style_guide.rst
+++ b/docs/source/style_guide.rst
@@ -31,10 +31,10 @@ Heading 4
 Lists
 =====
 
-#. Automatic numbered list
-#. Automatic numbered list again
+#. Automatic numbered list item 1
+#. Automatic numbered list item 2
 
-Bulletd list. Make sure there is a line space between this paragraph and the start of the list.
+Bulleted list. Make sure there is a line space between this paragraph and the start of the list.
 
 - Item a
 - Item b

--- a/docs/source/substitutions.rst
+++ b/docs/source/substitutions.rst
@@ -1,5 +1,0 @@
-Substitutions
-#############
-
-.. |App| replace:: AndBible
-


### PR DESCRIPTION
- Complete Documents.rst "ToDo" items, add links to other documentation pages.

- Remove unused (?) `substitutions.rst` file. (I believe the substitutions defined in `conf.py` are sufficient (can someone confirm?)

- Updated copyright date to 2025 in `conf.py`

- update links on bookmarks.rst to use `:doc:` links instead of full urls.